### PR TITLE
refactor: update logger types and default options for console and stdout plugins

### DIFF
--- a/.changeset/rotten-dragons-wish.md
+++ b/.changeset/rotten-dragons-wish.md
@@ -1,0 +1,16 @@
+---
+"@hyperse/logger-plugin-console": patch
+"@hyperse/logger-plugin-stdout": patch
+"@hyperse/logger": patch
+---
+
+### 🐛 Bug Fixes
+
+- Improved documentation for default values in console plugin options.
+- Improved documentation for default values in stdout plugin options.
+
+### 🏷️ Types
+
+- Exported the `Logger` type for external usage.
+
+

--- a/packages/logger-plugin-console/README.md
+++ b/packages/logger-plugin-console/README.md
@@ -130,13 +130,13 @@ If `true`, each message will have the level name attached to it.
 [ VERBOSE ] Verbose information
 ```
 
-- **Default**: `false`
+- **Default**: `true`
 
 ### `capitalizeLevelName?: boolean`
 
 If `true`, the level name will be capitalized.
 
-- **Default**: `false`
+- **Default**: `true`
 
 ### `showDate?: boolean`
 
@@ -160,7 +160,7 @@ If `true`, each message will have a timestamp attached to it.
 [ 13:43:10.23 ] bar
 ```
 
-- **Default**: `false`
+- **Default**: `true`
 
 ### `use24HourClock?: boolean`
 
@@ -178,7 +178,7 @@ If `true`, timestamps will use 24-hour format instead of 12-hour format.
 [ 1:27:55.33 PM ] pow
 ```
 
-- **Default**: `false`
+- **Default**: `true`
 
 ### `showArrow?: boolean`
 

--- a/packages/logger-plugin-console/src/types/type-options.ts
+++ b/packages/logger-plugin-console/src/types/type-options.ts
@@ -42,13 +42,13 @@ export type ConsoleOptions = {
    *
    * `[ FATAL ] WHAT WILL I DO?!`
    *
-   * @default false
+   * @default true
    */
   showLevelName?: boolean;
 
   /**
    * If true, the level name will be capitalized
-   * @default false
+   * @default true
    */
   capitalizeLevelName?: boolean;
 
@@ -64,7 +64,7 @@ export type ConsoleOptions = {
    * If true, each message logged to the terminal will have a timestamp corresponding to the exact time the message was logged.
    *
    * `[ 13:43:10.23 ] bar`
-   * @default false
+   * @default true
    */
   showTimestamp?: boolean;
 
@@ -78,7 +78,7 @@ export type ConsoleOptions = {
    * ### **12 hour clock:**
    *
    * `[ 1:27:55.33 PM ] pow`
-   * @default false
+   * @default true
    */
   use24HourClock?: boolean;
 

--- a/packages/logger-plugin-stdout/README.md
+++ b/packages/logger-plugin-stdout/README.md
@@ -130,13 +130,13 @@ If `true`, each message will have the level name attached to it.
 [ VERBOSE ] Verbose information
 ```
 
-- **Default**: `false`
+- **Default**: `true`
 
 ### `capitalizeLevelName?: boolean`
 
 If `true`, the level name will be capitalized.
 
-- **Default**: `false`
+- **Default**: `true`
 
 ### `showDate?: boolean`
 
@@ -160,7 +160,7 @@ If `true`, each message will have a timestamp attached to it.
 [ 13:43:10.23 ] bar
 ```
 
-- **Default**: `false`
+- **Default**: `true`
 
 ### `use24HourClock?: boolean`
 
@@ -178,7 +178,7 @@ If `true`, timestamps will use 24-hour format instead of 12-hour format.
 [ 1:27:55.33 PM ] pow
 ```
 
-- **Default**: `false`
+- **Default**: `true`
 
 ### `showArrow?: boolean`
 

--- a/packages/logger-plugin-stdout/src/types/type-options.ts
+++ b/packages/logger-plugin-stdout/src/types/type-options.ts
@@ -43,13 +43,13 @@ export type StdoutOptions = {
    *
    * `[ FATAL ] WHAT WILL I DO?!`
    *
-   * @default false
+   * @default true
    */
   showLevelName?: boolean;
 
   /**
    * If true, the level name will be capitalized
-   * @default false
+   * @default true
    */
   capitalizeLevelName?: boolean;
 
@@ -65,7 +65,7 @@ export type StdoutOptions = {
    * If true, each message logged to the terminal will have a timestamp corresponding to the exact time the message was logged.
    *
    * `[ 13:43:10.23 ] bar`
-   * @default false
+   * @default true
    */
   showTimestamp?: boolean;
 
@@ -79,7 +79,7 @@ export type StdoutOptions = {
    * ### **12 hour clock:**
    *
    * `[ 1:27:55.33 PM ] pow`
-   * @default false
+   * @default true
    */
   use24HourClock?: boolean;
 

--- a/packages/logger/src/core/create-logger.ts
+++ b/packages/logger/src/core/create-logger.ts
@@ -1,5 +1,6 @@
 import type { DeepPartial, LoggerMessage } from '../types/index.js';
 import type { LoggerContext } from '../types/type-logger.js';
+import type { Logger as BaseLogger } from '../types/type-logger.js';
 import { Logger } from './logger.js';
 
 export const createLogger = <
@@ -12,6 +13,6 @@ export const createLogger = <
       | Promise<DeepPartial<LoggerContext<Context>>>;
     errorHandling?: (error: Error) => void;
   }
-) => {
+): BaseLogger<LoggerContext<Context>, Message> => {
   return new Logger<Context, Message>(options);
 };

--- a/packages/logger/src/core/logger.ts
+++ b/packages/logger/src/core/logger.ts
@@ -10,7 +10,10 @@ import { LogLevel } from '../constant/log-level.js';
 import { executeFunction } from '../helpers/helper-execute-fun.js';
 import { mergeOptions } from '../helpers/helper-merge-options.js';
 import { simpleDeepClone } from '../helpers/helper-simple-deep-clone.js';
-import type { BaseLogger, LoggerContext } from '../types/type-logger.js';
+import type {
+  Logger as BaseLogger,
+  LoggerContext,
+} from '../types/type-logger.js';
 import type { LoggerPlugin } from '../types/type-logger-plugin.js';
 import type { LoggerMessage } from '../types/type-message.js';
 import type { DeepPartial } from '../types/type-partial-deep.js';

--- a/packages/logger/src/types/type-logger.ts
+++ b/packages/logger/src/types/type-logger.ts
@@ -12,15 +12,15 @@ export type LoggerPluginList<
   Message extends LoggerMessage,
 > = Array<LoggerPlugin<Context, Message>>;
 
-export interface BaseLogger<
-  Context extends LoggerContext,
-  Message extends LoggerMessage,
+export interface Logger<
+  Context extends LoggerContext = LoggerContext,
+  Message extends LoggerMessage = LoggerMessage,
 > {
   use: (
     ...plugins: LoggerPlugin<Context, Message>[]
-  ) => Pick<BaseLogger<Context, Message>, 'use' | 'build'>;
+  ) => Pick<Logger<Context, Message>, 'use' | 'build'>;
   build: () => Pick<
-    BaseLogger<Context, Message>,
+    Logger<Context, Message>,
     'debug' | 'info' | 'warn' | 'error' | 'verbose'
   >;
   debug: (message: Message) => void;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `Logger` type is now exported for external use, allowing easier integration and type referencing.

* **Documentation**
  * Updated documentation for logger plugins to clarify and correct default values for configuration options, reflecting that several formatting options now default to `true`.

* **Refactor**
  * Updated default values for various logging options, so features like displaying level names, timestamps, and using a 24-hour clock are enabled by default. 
  * Renamed and updated internal type declarations for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->